### PR TITLE
Extend Content-Security-Policy for launch countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Can be further customized with the properties below.
 ``content_security_policy_style_src`` (*safe string*): String to use instead of the default for the ``script_src`` rule of the site's CSP (if enabled).
 *Example:* ``content_security_policy_style_src = 'self' https://fonts.googleapis.com 'unsafe-inline'``
 
+``content_security_policy_connect_src`` (*safe string*): String to use instead of the default for the ``connect-src`` rule of the site's CSP (if enabled).
+*Example:* ``content_security_policy_connect_src = 'self' https://api.foo.bar``
+
 ``loader_enable`` (*boolean*): Whether to show the animated loading icon for a brief period while any singlepage-theme page is loading.
 Defaults to true if not set.
 *Example:* ``loader_enable = true``

--- a/example-site/lektor_icon_example.lektorproject
+++ b/example-site/lektor_icon_example.lektorproject
@@ -20,6 +20,7 @@ content_security_policy = true
 content_security_policy_frame_src =
 content_security_policy_script_src =
 content_security_policy_style_src =
+content_security_policy_connect_src =
 loader_enable = true
 nav_logo_path = /static/images/spyder-logo.svg
 nav_logo_text = Lektor-Icon

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -35,6 +35,11 @@
 {% if config.THEME_SETTINGS.content_security_policy_style_src %}
 {% set style_src = style_src ~ " " ~ config.THEME_SETTINGS.content_security_policy_style_src %}
 {% endif %}
+{% if config.THEME_SETTINGS.content_security_policy_connect_src %}
+{% set connect_src = " " ~ config.THEME_SETTINGS.content_security_policy_connect_src %}
+{% else %}
+{% set connect_src = ""  %}
+{% endif %}
 
 base-uri 'self';
 default-src 'self';
@@ -43,6 +48,7 @@ frame-src {{ frame_src }}{% block csp_extra_framesrc %}{% endblock %};
 img-src {{ img_src }}{% block csp_extra_imgsrc %}{% endblock %};
 script-src {{ script_src }}{% block csp_extra_scriptsrc %}{% endblock %};
 style-src {{ style_src }}{% block csp_extra_stylesrc %}{% endblock %};
+connect-src {{ connect_src }}{% block csp_extra_connectsrc %}{% endblock %};
 ">
   {% elif config.THEME_SETTINGS.content_security_policy.lower() not in ["false", "f", "no", "n"] %}
   <meta http-equiv="Content-Security-Policy" content="{{ config.THEME_SETTINGS.content_security_policy | safe }}">


### PR DESCRIPTION
The theme includes a `<meta http-equiv="Content-Security-Policy">` tag with some flexibility, but it offers no provisions for specifying [`connect-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src). This PR adds `connect-src https://api.spacexdata.com;` to the policy, since that seemed simpler than making it add an extra knob and having a separate PR turn it.